### PR TITLE
feat: reading list

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
 	"scripts": {
 		"dev": "astro dev",
 		"start": "astro dev",
-		"build": "astro build",
-		"postbuild": "pagefind --site dist",
+		"build": "astro build && pagefind --site dist",
 		"preview": "astro preview",
 		"lint:check": "eslint . --no-fix",
 		"lint": "eslint .",


### PR DESCRIPTION

Static search build was not included in the build command; thus the astro gh action would not have the static search build step. 