### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/qdelettre/qdelettre.github.io/security/code-scanning/1](https://github.com/qdelettre/qdelettre.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily needs `contents: read` to check out the repository and read files. No write permissions are necessary for the current operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
