### PR TITLE
ci(playwright): post PR comment with test summary

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 
 concurrency:
   group: playwright-${{ github.event.workflow_run.head_branch || github.ref }}
@@ -61,3 +62,10 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - name: Publish report summary
+        if: always() && github.event_name == 'workflow_run'
+        uses: daun/playwright-report-summary@v3
+        with:
+          report-file: playwright-report/report.json
+          comment-title: Playwright results

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
-	reporter: [["list"], ["html", { open: "never" }]],
+	reporter: [
+		["list"],
+		["html", { open: "never" }],
+		["json", { outputFile: "playwright-report/report.json" }],
+	],
 	use: {
 		baseURL: "http://localhost:4321",
 		trace: "retain-on-failure",


### PR DESCRIPTION
## Summary

- Adds JSON reporter to `playwright.config.ts`.
- Adds `daun/playwright-report-summary@v3` step to `.github/workflows/playwright.yml`, gated on `workflow_run` event.
- Grants `pull-requests: write` to the playwright workflow so the action can post/update the PR comment.

Surfaces pass/fail/duration on PRs without hosting the HTML report. Keeps the existing `workflow_run` chain (no rebuild — playwright still reuses the build job's `dist` artifact).

## Notes

- `daun/playwright-report-summary@v3` reads `github.event.workflow_run.pull_requests` — same-repo only. Fork PRs silently no-op (not a concern here; dependabot is same-repo).
- `@v3` is a mutable tag. Consider pinning to a commit SHA in a follow-up — dependabot will keep it fresh.
- JSON reporter is always-on (no `CI` gate). Cheap, and keeps `report-file` path consistent local/CI.

## Test plan

- [ ] Merge to `main` so `workflow_run` triggers on subsequent PRs (files must exist on default branch).
- [ ] Open a throwaway PR with a deliberate test failure → confirm comment renders with failure detail.
- [ ] Confirm `report.json` does not leak into commits (gitignored via `playwright-report/`).