### PR TITLE
ci(lighthouse): harden against artifact poisoning and untrusted checkout

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: [build]
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,7 +11,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: lighthouse-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: lighthouse-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
@@ -20,24 +19,21 @@ jobs:
     name: Lighthouse CI
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.head_repository.fork == false
     steps:
-      - name: Checkout
+      - name: Checkout trusted ref (base repo default branch)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download dist artifact (auto path)
-        if: github.event_name == 'workflow_run'
+      - name: Download dist artifact
         uses: actions/download-artifact@v8
         with:
           name: dist
@@ -45,26 +41,21 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build (manual dispatch path)
-        if: github.event_name == 'workflow_dispatch'
-        run: npm run build
-
       - name: Verify resolved build context
         env:
-          RESOLVED_HASH: ${{ github.event.workflow_run.head_sha || github.sha }}
-          RESOLVED_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          RESOLVED_HASH: ${{ github.event.workflow_run.head_sha }}
+          RESOLVED_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           echo "Resolved current_hash:   $RESOLVED_HASH"
           echo "Resolved current_branch: $RESOLVED_BRANCH"
-          echo "Trigger event:           ${{ github.event_name }}"
           test -n "$RESOLVED_HASH" || { echo "::error::CURRENT_HASH is empty — LHCI would post against the wrong ref"; exit 1; }
 
       - name: Run Lighthouse CI
         run: npx --yes @lhci/cli@0.15.x autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-          LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.event.workflow_run.head_sha || github.sha }}
-          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
-          LHCI_BUILD_CONTEXT__COMMIT_TIME: ${{ github.event.workflow_run.head_commit.timestamp || '' }}
-          LHCI_BUILD_CONTEXT__COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message || '' }}
-          LHCI_BUILD_CONTEXT__AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.actor }}
+          LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.event.workflow_run.head_sha }}
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          LHCI_BUILD_CONTEXT__COMMIT_TIME: ${{ github.event.workflow_run.head_commit.timestamp }}
+          LHCI_BUILD_CONTEXT__COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          LHCI_BUILD_CONTEXT__AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}


### PR DESCRIPTION
## Summary

Closes three critical code-scanning alerts in `.github/workflows/lighthouse.yml`:

- **#4** `actions/artifact-poisoning/critical` — `dist` artifact from `workflow_run` may be controlled by a forked PR.
- **#3 / #2** `actions/untrusted-checkout/critical` — privileged workflow (with `pull-requests: write` + `LHCI_GITHUB_APP_TOKEN`) checked out the PR `head_sha` and executed `npm ci` and `npm run build` from it.

A fork PR could execute arbitrary code on the privileged runner via npm lifecycle scripts (`preinstall`/`postinstall`) or via build scripts in its `package.json`, and could leak the LHCI app token.

## Hardening

1. **Drop `workflow_dispatch` trigger.** Manual LHCI runs go local. Eliminates the second untrusted-checkout site.
2. **Check out the workflow's own (base) ref** instead of `head_sha`. `lighthouserc.cjs` is now always the trusted version from the default branch. A PR that wants to change LHCI config has to merge first. Adds `persist-credentials: false`.
3. **Fork guard.** `if: github.event.workflow_run.head_repository.fork == false` — skip the run entirely when the upstream build came from a fork. Trades fork-PR LHCI comments (low value on a personal site) for closing the artifact-poisoning surface.
4. **No `npm ci`, no `npm run build`.** `lighthouserc.cjs` only uses `node:fs` / `node:path`, and `npx --yes @lhci/cli@0.15.x` fetches LHCI standalone. No project deps are needed at runtime.
5. The `dist` artifact is still downloaded and served as static files by LHCI's built-in server; nothing in it is executed on the runner.

## Test plan

- [ ] Open this PR, confirm code-scanning shows alerts #2 / #3 / #4 resolved on the branch.
- [ ] After merge, push a non-PR commit to `main` and confirm the `lighthouse` workflow still triggers from `workflow_run` and posts an LHCI comment.
- [ ] Open a same-repo PR and confirm the LHCI comment still appears.
- [ ] (Optional) Open a fork PR and confirm `lighthouse` is skipped (the fork guard fires).