### PR TITLE
ci(playwright-comment): pass pr-number for workflow_run context

### DIFF
--- a/.github/workflows/playwright-comment.yml
+++ b/.github/workflows/playwright-comment.yml
@@ -19,6 +19,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.head_repository.fork == false
+      && github.event.workflow_run.pull_requests[0].number != null
     permissions:
       contents: read
       actions: read
@@ -42,3 +43,4 @@ jobs:
         with:
           report-file: playwright-report/report.json
           comment-title: Playwright results
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary

Follow-up to #787. The split-job pattern uses a `workflow_run` listener (`playwright-comment.yml`) to post the test summary back to the PR. The action `daun/playwright-report-summary` only auto-detects PR context from `pull_request` events; under `workflow_run` it logs:

```
Unsupported event type: workflow_run
No PR associated with this action run. Not posting a check or comment.
```

…then exits successfully without posting.

## Fix

Resolve the PR number from `github.event.workflow_run.pull_requests[0].number` and pass it to the action via the documented `pr-number` input. That array is populated for same-repo PRs; fork PRs are already gated out by `head_repository.fork == false`.

Also tightened the job `if:` so a `workflow_run` triggered by anything that isn't a real PR (e.g. a manual `workflow_dispatch` of `playwright`) no-ops cleanly instead of trying to comment with a `null` PR number.

## Test plan

- [ ] After merge, next PR's `Playwright tests` run completes
- [ ] `playwright-comment` workflow_run posts the `Playwright results` comment on the PR
- [ ] CodeQL re-scan stays at 0 open alerts on `playwright-comment.yml`